### PR TITLE
Use python3 for cython source

### DIFF
--- a/src/libtfr.pyx
+++ b/src/libtfr.pyx
@@ -201,7 +201,7 @@ cdef class mfft:
         t0, tN, - start and stop of the signal
         returns array of complex numbers, dimension (nreal, ntapers)
         """
-        cdef int i
+        cdef unsigned int i
         cdef double tw0, Msp
         cdef nx.ndarray[DTYPE_t, ndim=2] ht
         cdef nx.ndarray[DTYPE_t] times = nx.asarray(t).astype(DTYPE)

--- a/src/libtfr.pyx
+++ b/src/libtfr.pyx
@@ -305,7 +305,7 @@ def tfr_spec(s not None, int N, int step, int Np, int K=6,
     cdef double[:] samples = nx.asarray(s).astype(DTYPE)
 
     # generate/convert frequency grid
-    cdef int nfreq = N/2 + 1
+    cdef int nfreq = N//2 + 1
     cdef nx.ndarray[DTYPE_t, ndim=1] fgrid_cast
     cdef double * fgridp = NULL
     if fgrid is not None:
@@ -378,8 +378,8 @@ cdef void hc2cmplx(tfr.mfft * mtm, CTYPE_t[:,:] out) nogil:
     """Copy data from workspace of mtm object into a complex array"""
     cdef size_t nfft = tfr.mtm_nfft(mtm)
     cdef size_t ntapers = tfr.mtm_ntapers(mtm)
-    cdef size_t real_count = nfft / 2 + 1
-    cdef size_t imag_count = (nfft + 1) / 2
+    cdef size_t real_count = nfft // 2 + 1
+    cdef size_t imag_count = (nfft + 1) // 2
     cdef size_t t, n
     cdef double * buf = tfr.mtm_buffer(mtm)
 

--- a/src/libtfr.pyx
+++ b/src/libtfr.pyx
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # -*- mode: cython -*-
+#cython: language_level=3
 """Interface to libtfr spectrogram library using numpy.
 
 Spectrograms are returned as 2D arrays with frequency indexed by row and time by


### PR DESCRIPTION
It didn't specify python2 vs 3 and was currently default to python2.  Switch to 3.

There are few fixes after doing this.