### PR TITLE
Use binary search with supplied frequency grid

### DIFF
--- a/src/tfr.c
+++ b/src/tfr.c
@@ -94,16 +94,21 @@ mtm_init_herm(int nfft, int npoints, int order, double tm)
  *
  */
 static int
-find_bin(double f, const double *fgrid, int nfreq) {
-        double diff;
-        int i;
-        if (f < *fgrid || f > fgrid[nfreq-1]) return -1;
-        for (i = 1; i < nfreq; i++) {
-                diff = fgrid[i] - f;
-                if (diff >= 0)
-                        return ((f-fgrid[i-1]) < diff) ? i-1 : i;
+find_bin(double f, const double *fgrid, int nfreq)
+{
+        int i = 0, j = nfreq - 1;
+
+        if (f < fgrid[i] || f > fgrid[j]) return -1;
+
+        while (j - i > 1) {
+                int k = (i + j) / 2;
+                if (f > fgrid[k])
+                        i = k;
+                else
+                        j = k;
         }
-        return -1;
+
+        return (f - fgrid[i] < fgrid[j] - f) ? i : j;
 }
 
 void


### PR DESCRIPTION
If fgrid is supplied a linear search is used to find the frequency bin. This is rather slow.

A test of tfr_spec with len(s)==19670, N = 1024, step = 16, Np = 257, took ~73 ms.  Adding an fgrid argument about equal to the default fgrid, np.linspace(0, 0.5, N//2 + 1), increases that time to 505 ms.

After this change, the supplied fgrid version only takes 128 ms.

So this increases the speed almost four times.

Of course it depends on the exact grid and how the points are distributed.  Most points in the first bin is good for a linear search while most points in the last is very bad.

The binary search will be more consistent.  E.g., fgrid=np.logspace(-2, 0, N//2+1)/2 is about 738 ms with the linear search but 123 ms with the binary search.