### PR TITLE
Zero Pkm2 array in hermf

### DIFF
--- a/src/tfr.c
+++ b/src/tfr.c
@@ -73,6 +73,8 @@ hermf(int N, int M, double tm, double *h, double *Dh, double *Th)
         // This way we only need two rows of P values at once.
         double *Pkm2 = P+N, *Pkm1 = P, *Pk = P+N;
 
+        memset(Pkm2, 0, sizeof(*Pkm2) * N);
+
         // Note that on the first iteration (k=1), Pkm2 is uninitialized, but it is
         // multiplied by (k-1) = 0, so it doesn't matter.
         for (k = 1; k < M; k++) {


### PR DESCRIPTION
Fixes issue #17

The P values for k = 1..M are computed using the values from the previous two k.

On the first iteration, k=1, we need the values for k=0, computed before the k loop started, and for k=-1, which are all zero, but the location in the P array where they are was never zerod.  So garbage was used, but that garbage was often all zero by chance, so everything worked.